### PR TITLE
docs(readme): expand project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,72 @@
 # Runeweave — Rite I Scaffold
 
-Local‑first ritual UX for AI composition. MVP includes Veil, Scriptorium (LML), Grimoire, Reliquary, Bestiary (mock), Crucible stub.
+Runeweave is a local-first, browser-native toolkit for composing AI interactions. Rite I delivers a minimal ritual UX with a SvelteKit web app and a set of reusable TypeScript packages.
 
-## Quickstart
+## Overview
+
+Runeweave treats prompt design as weaving. A weave is defined in **LML** (a structured prompt language) and persisted locally so it can be revisited, remixed and enshrined. The current modules include:
+
+- **Veil of Unknowing** – a focus gate that can be skipped or opens after calm.
+- **Scriptorium** – LML editor with compiled preview.
+- **Grimoire** – auto-logged folios of model casts.
+- **Reliquary** – list of enshrined weaves.
+- **Bestiary** – mock model profiles and stats.
+- **Crucible** – lens fusion stub.
+
+Everything runs locally. The web app can be wrapped for desktop via a Tauri shell in `apps/desktop`. Persistence uses IndexedDB via Dexie and model calls use a deterministic MockAdapter. No telemetry or external network calls are made in Rite I.
+
+## Monorepo Structure
+
+```
+/ (root)
+├── apps/
+│   ├── desktop/            # Tauri wrapper
+│   └── web/                # SvelteKit + Tailwind web app
+├── packages/
+│   ├── core/               # types, LML compiler, state machines
+│   ├── adapters/           # ModelAdapter interface + MockAdapter
+│   ├── data/               # Dexie schema and helpers
+│   └── ui/                 # shared Svelte components
+├── docs/
+│   ├── AGENTS_GUIDE.md     # workflow rules for agents
+│   └── decisions/          # architecture decision records
+├── .github/workflows/ci.yml
+├── package.json            # root scripts
+└── pnpm-workspace.yaml
+```
+
+## Getting Started
+
+Prerequisites: [Node.js 20](https://nodejs.org/) and [pnpm](https://pnpm.io) 9.
 
 ```bash
-# require Node 20 + pnpm
-nvm use
-pnpm -w install
-pnpm -w dev    # runs apps/web
-pnpm -w test   # runs package tests
+nvm use             # ensure Node 20
+pnpm -w install     # install all workspace deps
+pnpm -w dev         # run apps/web in dev mode
+pnpm -w test        # run package tests
+pnpm -w build       # build the web app
 ```
 
-## Structure
+Each package can be developed independently with `pnpm -F <package> <script>`.
 
-```
-runeweave/
-  apps/
-    web/       # SvelteKit app (browser)
-    desktop/   # Tauri wrapper (stub)
-  packages/
-    core/      # types, LML, state machines, utilities
-    adapters/  # ModelAdapter implementations
-    data/      # Dexie schema/wrappers
-    ui/        # reusable Svelte components
-  docs/
-    AGENTS_GUIDE.md
-    decisions/
-  .github/workflows/ci.yml
-  .editorconfig
-  pnpm-workspace.yaml
-  .nvmrc
-  package.json
-```
+## Packages
 
-See `docs/AGENTS_GUIDE.md` for agent workflow and `docs/decisions/*` for ADRs.
+| Package               | Purpose                                                |
+| --------------------- | ------------------------------------------------------ |
+| `@runeweave/core`     | Type definitions, LML compiler, ritual state machines. |
+| `@runeweave/adapters` | ModelAdapter interface with deterministic MockAdapter. |
+| `@runeweave/data`     | Dexie wrapper for weaves, folios and model profiles.   |
+| `@runeweave/ui`       | Shared Svelte components (stub for future use).        |
 
-## No Cloud, No Tracking
+## Development Workflow
 
-Runeweave stores all data locally (IndexedDB now, SQLite in desktop builds). There is no telemetry, analytics, or remote storage.
+- **Tests**: [Vitest](https://vitest.dev/) and [`@testing-library/svelte`](https://testing-library.com/docs/svelte-testing-library/intro/).
+- **Formatting/Linting**: [pre-commit](https://pre-commit.com/) runs Prettier and whitespace checks.
+- **CI**: GitHub Actions (Node 20) runs lint, tests and builds.
+- **Commit style**: Conventional Commits `feat|fix|docs|chore|refactor(scope): summary`.
+
+See [docs/AGENTS_GUIDE.md](docs/AGENTS_GUIDE.md) for the full agent workflow and [docs/decisions](docs/decisions) for ADRs.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/packages/core/test/lml.test.ts
+++ b/packages/core/test/lml.test.ts
@@ -5,6 +5,9 @@ describe("compile(LML)", () => {
   it("handles empty", () => {
     expect(compile({})).toBe("");
   });
+  it("handles minimal invocation", () => {
+    expect(compile({ invocation: "Hi" })).toBe("Invocation: Hi");
+  });
   it("compiles key sections deterministically", () => {
     const out = compile({
       invocation: "Teach with reverent clarity.",


### PR DESCRIPTION
## Type
- [ ] feat  [ ] fix  [x] docs  [ ] chore  [ ] refactor

## Summary
Expanded root README with a full project overview and development workflow, added documentation for the desktop Tauri wrapper, and added a minimal invocation test for the LML compiler so empty/minimal/full cases are covered.

## Affected Packages
- [ ] apps/web
- [x] packages/core
- [ ] packages/adapters
- [ ] packages/data

## Test Plan
- `pre-commit run --files README.md`
- `pnpm -w test`

## Checklist
- [ ] CI green
- [x] Added/updated tests
- [x] Updated docs (README/AGENTS_GUIDE/ADR if needed)


------
https://chatgpt.com/codex/tasks/task_e_68a3f9b32934832791371af91806850f