### PR TITLE
chore(ci): add macOS and Windows CI placeholders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,13 @@ jobs:
 
       - name: Build web
         run: pnpm -C apps/web build
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - run: 'echo "TODO: implement macOS CI pipeline"'
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - run: 'echo "TODO: implement Windows CI pipeline"'

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each package can be developed independently with `pnpm -F <package> <script>`.
 
 - **Tests**: [Vitest](https://vitest.dev/) and [`@testing-library/svelte`](https://testing-library.com/docs/svelte-testing-library/intro/).
 - **Formatting/Linting**: [pre-commit](https://pre-commit.com/) runs Prettier and whitespace checks.
-- **CI**: GitHub Actions (Node 20) runs lint, tests and builds.
+- **CI**: GitHub Actions (Node 20) runs lint, tests and builds. Placeholder jobs for macOS and Windows exist for future platform coverage.
 - **Commit style**: Conventional Commits `feat|fix|docs|chore|refactor(scope): summary`.
 
 See [docs/AGENTS_GUIDE.md](docs/AGENTS_GUIDE.md) for the full agent workflow and [docs/decisions](docs/decisions) for ADRs.

--- a/docs/tasks/cross-platform-ci.md
+++ b/docs/tasks/cross-platform-ci.md
@@ -1,0 +1,24 @@
+**Goal:** Implement full CI runs on macOS and Windows.
+
+**Files:**
+
+- `.github/workflows/ci.yml`
+
+**Implementation notes:**
+
+- mirror Linux steps for macOS and Windows
+- ensure tooling (Node, pnpm, pre-commit) works cross-platform
+- add build steps for desktop wrapper when implemented
+
+**Tests:**
+
+- `pnpm -w lint`
+- `pnpm -w test`
+
+**Docs:**
+
+- update `README.md` with platform support
+
+**Acceptance:**
+
+- CI jobs pass on macOS and Windows


### PR DESCRIPTION
## Summary
- scaffold macOS and Windows CI jobs as placeholders
- document follow-up task for cross-platform CI
- note future platform coverage in README

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/tasks/cross-platform-ci.md README.md`
- `pnpm -w lint`
- `pnpm -w test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ff0b5f7c83278546a57623363e90