### PR TITLE
docs: document cosmology and covenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ Runeweave treats prompt design as weaving. A weave is defined in **LML** (a stru
 - **Reliquary** – list of enshrined weaves.
 - **Bestiary** – mock model profiles and stats.
 - **Crucible** – lens fusion stub.
+- **Choir** – choral interaction stub.
+- **Codex of Errors** – miscast compendium stub.
 
-Everything runs locally. The web app can be wrapped for desktop via a Tauri shell in `apps/desktop`. Persistence uses IndexedDB via Dexie and model calls use a deterministic MockAdapter. No telemetry or external network calls are made in Rite I.
+**Covenants**
+
+- Local-first.
+- No telemetry.
+- WCAG AA+ with Vigil Mode.
+- Svelte 5 runes for local state/effects; Svelte stores only cross-route.
+
+The web app can be wrapped for desktop via a Tauri shell in `apps/desktop`. Persistence uses IndexedDB via Dexie and model calls use a deterministic MockAdapter.
 
 ## Monorepo Structure
 

--- a/docs/ARCHITECTURE_CHECKLIST.md
+++ b/docs/ARCHITECTURE_CHECKLIST.md
@@ -2,6 +2,13 @@
 
 This document is the authoritative reference for the current architecture. Every pull request must check the items below and update the checklist when the architecture changes.
 
+## Invariants
+
+- Local-first.
+- No telemetry.
+- WCAG AA+ with Vigil Mode.
+- Svelte 5 runes for local state/effects; Svelte stores only cross-route.
+
 ## Repo Layout
 
 - `apps/web` – SvelteKit + Tailwind web app
@@ -20,7 +27,7 @@ This document is the authoritative reference for the current architecture. Every
 - [ ] **R1-06**: `packages/adapters` defines `ModelAdapter` and a deterministic `MockAdapter`.
 - [ ] **R1-07**: `packages/data` supplies Dexie schema and helpers for IndexedDB.
 - [ ] **R1-08**: `packages/ui` hosts reusable Svelte components.
-- [ ] **R1-09**: Core modules exist — Veil of Unknowing, Scriptorium, Grimoire, Reliquary, Bestiary, Crucible.
+- [ ] **R1-09**: Core modules exist — Veil of Unknowing, Scriptorium, Grimoire, Reliquary, Bestiary, Crucible, Choir, Codex of Errors.
 - [ ] **R1-10**: LML is canonical; compiled prompts are cached and regenerable.
 - [ ] **R1-11**: Runtime is local-only with deterministic model calls; no external network requests.
 - [ ] **R1-12**: Tests use Vitest and `@testing-library/svelte` with deterministic outputs.


### PR DESCRIPTION
## Summary
- list full cosmology including Choir and Codex of Errors
- spell out covenants for local-first, no telemetry, WCAG AA+ with Vigil Mode, and Svelte 5 runes + stores
- echo covenants in architecture checklist and update core module list

## Testing
- `pnpm -w lint`
- `pnpm -w test`


------
https://chatgpt.com/codex/tasks/task_e_68a425b793b883279776de5a6d68cc01