### PR TITLE
refactor(svelte): remove onMount in favor of runes

### DIFF
--- a/apps/web/src/lib/components/Veil.svelte
+++ b/apps/web/src/lib/components/Veil.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { nextVeilState, type VeilState } from '@runeweave/core/src/veil';
 
   let state = $state<VeilState>('covered');
@@ -10,7 +9,7 @@
     if (e.key === 'Escape') openNow();
   };
 
-  onMount(() => {
+  $effect.root(() => {
     state = nextVeilState(state, 'mount');
     let activity = false;
     const mark = () => (activity = true);

--- a/apps/web/src/routes/bestiary/+page.svelte
+++ b/apps/web/src/routes/bestiary/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { db } from '@runeweave/data/src/db';
-  import { onMount } from 'svelte';
 
-  let casts = 0;
-  onMount(async () => {
-    casts = await db.folios.count();
+  let casts = $state(0);
+  $effect(() => {
+    void db.folios.count().then(c => (casts = c));
   });
 </script>
 

--- a/apps/web/src/routes/crucible/+page.svelte
+++ b/apps/web/src/routes/crucible/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  const lenses = ['Rhetoric','Persona','Structure','Tone','Imagery'];
-  let a = lenses[0];
-  let b = lenses[1];
-  $: descriptor = `Fuse ${a} with ${b}`;
+  const lenses = ['Rhetoric', 'Persona', 'Structure', 'Tone', 'Imagery'];
+  let a = $state(lenses[0]);
+  let b = $state(lenses[1]);
+  let descriptor = $derived(() => `Fuse ${a} with ${b}`);
 </script>
 
 <h1 class="text-xl font-bold mb-2">Crucible</h1>

--- a/apps/web/src/routes/grimoire/+page.svelte
+++ b/apps/web/src/routes/grimoire/+page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { db } from '@runeweave/data/src/db';
-  import { onMount } from 'svelte';
   import type { Folio } from '@runeweave/core/src/types';
 
-  let folios: Folio[] = [];
-  onMount(async () => {
-    folios = await db.folios.toArray();
+  let folios = $state<Folio[]>([]);
+  $effect(() => {
+    void db.folios.toArray().then(f => (folios = f));
   });
 </script>
 

--- a/apps/web/src/routes/reliquary/+page.svelte
+++ b/apps/web/src/routes/reliquary/+page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { db } from '@runeweave/data/src/db';
-  import { onMount } from 'svelte';
   import type { Weave } from '@runeweave/core/src/types';
 
-  let weaves: Weave[] = [];
-  onMount(async () => {
-    weaves = await db.weaves.filter(w => w.enshrined).toArray();
+  let weaves = $state<Weave[]>([]);
+  $effect(() => {
+    void db.weaves.filter(w => w.enshrined).toArray().then(w => (weaves = w));
   });
 </script>
 

--- a/docs/ARCHITECTURE_CHECKLIST.md
+++ b/docs/ARCHITECTURE_CHECKLIST.md
@@ -7,7 +7,7 @@ This document is the authoritative reference for the current architecture. Every
 - Local-first.
 - No telemetry.
 - WCAG AA+ with Vigil Mode.
-- Svelte 5 runes for local state/effects; Svelte stores only cross-route.
+- Local component state and effects must use Svelte 5 runes (`$state`, `$derived`, `$effect`); legacy lifecycles like `onMount` are forbidden. Svelte stores only cross-route.
 
 ## Repo Layout
 


### PR DESCRIPTION
## Summary
- remove onMount lifecycles in web components and pages
- convert local state to `$state`, `$derived`, `$effect`
- document rune-only local state in architecture checklist

## Testing
- `pre-commit run --files apps/web/src/lib/components/Veil.svelte apps/web/src/routes/grimoire/+page.svelte apps/web/src/routes/reliquary/+page.svelte apps/web/src/routes/bestiary/+page.svelte apps/web/src/routes/crucible/+page.svelte docs/ARCHITECTURE_CHECKLIST.md`
- `pnpm -w lint`
- `pnpm -w test`


------
https://chatgpt.com/codex/tasks/task_e_68a4271b31488327a38cbdad2f31decf