### PR TITLE
feat(reliquary): enshrine toggle with folio test

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "pretest": "svelte-kit sync",
     "test": "vitest run",
     "lint": "echo \"(todo)\" && exit 0",
     "fmt": "echo \"(prettier via pre-commit)\" && exit 0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"(no tests)\" && exit 0",
+    "test": "vitest run",
     "lint": "echo \"(todo)\" && exit 0",
     "fmt": "echo \"(prettier via pre-commit)\" && exit 0"
   },
@@ -27,6 +27,7 @@
     "typescript": "^5.5.4",
     "vite": "^6.3.0",
     "vitest": "^2.0.0",
-    "@testing-library/svelte": "^5.1.0"
+    "@testing-library/svelte": "^5.1.0",
+    "fake-indexeddb": "^4.0.2"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "tailwindcss": "^3.4.10",
     "postcss": "^8.4.41",
     "autoprefixer": "^10.4.20",
+    "dexie": "^4.0.7",
     "@runeweave/core": "workspace:*",
     "@runeweave/adapters": "workspace:*",
     "@runeweave/data": "workspace:*",

--- a/apps/web/src/routes/reliquary/+page.svelte
+++ b/apps/web/src/routes/reliquary/+page.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import { db } from '@runeweave/data/src/db';
   import type { Weave } from '@runeweave/core/src/types';
+  import { liveQuery } from 'dexie';
 
   let weaves = $state<Weave[]>([]);
   $effect(() => {
-    void db.weaves.filter(w => w.enshrined).toArray().then(w => (weaves = w));
+    const sub = liveQuery(() =>
+      db.weaves.filter(w => w.enshrined).toArray()
+    ).subscribe({
+      next: w => (weaves = w)
+    });
+    return () => sub.unsubscribe();
   });
 </script>
 

--- a/apps/web/src/routes/scribe/+page.svelte
+++ b/apps/web/src/routes/scribe/+page.svelte
@@ -5,7 +5,12 @@
 
   let lmlText = $state('{\n  "invocation": ""\n}');
   let output = $state('');
+  let enshrined = $state(false);
   const adapter = new MockAdapter();
+
+  $effect(() => {
+    void db.weaves.get('demo').then(w => (enshrined = w?.enshrined ?? false));
+  });
   const compiled = $derived(() => {
     try {
       return compile(JSON.parse(lmlText || '{}'));
@@ -25,10 +30,27 @@
       createdAt: Date.now()
     });
   }
+
+  async function toggleEnshrine() {
+    enshrined = !enshrined;
+    await db.weaves.put({
+      id: 'demo',
+      title: 'Demo',
+      lml: JSON.parse(lmlText || '{}'),
+      compiled,
+      enshrined,
+      createdAt: Date.now()
+    });
+  }
 </script>
 
 <textarea bind:value={lmlText} class="w-full h-40 border" aria-label="LML input"></textarea>
-<button class="mt-2 px-4 py-2 border" onclick={cast}>Cast</button>
+<div class="mt-2 flex gap-2">
+  <button class="px-4 py-2 border" onclick={cast}>Cast</button>
+  <button class="px-4 py-2 border" onclick={toggleEnshrine}>
+    {enshrined ? '✦ Enshrined' : '✧ Enshrine'}
+  </button>
+</div>
 <div class="mt-4 space-y-2">
   <div>
     <h2 class="font-bold">Compiled</h2>

--- a/apps/web/test/folio.test.ts
+++ b/apps/web/test/folio.test.ts
@@ -1,0 +1,32 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect } from "vitest";
+import { compile } from "@runeweave/core/src/lml";
+import { MockAdapter } from "@runeweave/adapters/src/model";
+import { db } from "@runeweave/data/src/db";
+
+describe("Folio casting", () => {
+  it("stores folio with expected shape", async () => {
+    const compiled = compile({ invocation: "" });
+    const adapter = new MockAdapter();
+    const output = await adapter.invoke({ user: compiled });
+    const id = crypto.randomUUID();
+    const now = Date.now();
+    await db.folios.add({
+      id,
+      weaveId: "demo",
+      model: "mock",
+      input: compiled,
+      output,
+      createdAt: now,
+    });
+    const stored = await db.folios.get(id);
+    expect(stored).toStrictEqual({
+      id,
+      weaveId: "demo",
+      model: "mock",
+      input: compiled,
+      output,
+      createdAt: now,
+    });
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.1.0
         version: 5.2.8(svelte@5.38.2)(vite@6.3.5(jiti@1.21.7)(yaml@2.8.1))(vitest@2.1.9(jsdom@25.0.1))
+      fake-indexeddb:
+        specifier: ^4.0.2
+        version: 4.0.2
       typescript:
         specifier: ^5.5.4
         version: 5.9.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
+      dexie:
+        specifier: ^4.0.7
+        version: 4.2.0
       postcss:
         specifier: ^8.4.41
         version: 8.5.6


### PR DESCRIPTION
## Summary
- add Enshrine toggle to Scribe page and persist Weaves to Dexie
- live-update Reliquary from Dexie using liveQuery
- add unit test to confirm Folio shape after casting

## Testing
- `pnpm test`
- `pre-commit run --files apps/web/package.json apps/web/src/routes/reliquary/+page.svelte apps/web/src/routes/scribe/+page.svelte apps/web/test/folio.test.ts apps/web/vitest.config.ts pnpm-lock.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68a4288c9ff083278149d6f9c894155f