### PR TITLE
feat(crucible): add lens fusion stub

### DIFF
--- a/apps/web/src/routes/crucible/+page.svelte
+++ b/apps/web/src/routes/crucible/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import { fuse } from '@runeweave/core/src/fusion';
+  import { compile } from '@runeweave/core/src/lml';
+
   const lenses = ['Rhetoric', 'Persona', 'Structure', 'Tone', 'Imagery'];
   let a = $state(lenses[0]);
   let b = $state(lenses[1]);
-  let descriptor = $derived(() => `Fuse ${a} with ${b}`);
+  const fusion = $derived(() => fuse(a, b));
+  const descriptor = $derived(() => fusion.descriptor);
+  const preview = $derived(() => compile(fusion.lml));
 </script>
 
 <h1 class="text-xl font-bold mb-2">Crucible</h1>
@@ -15,3 +20,4 @@
   </select>
 </div>
 <p class="mt-2">{descriptor}</p>
+<pre class="mt-2">{preview}</pre>

--- a/packages/core/src/fusion.ts
+++ b/packages/core/src/fusion.ts
@@ -1,13 +1,15 @@
-import type { LML } from './types';
+import type { LML } from "./types";
 
 /**
  * Deterministically combine two lens names.
  * This stub simply concatenates them and builds a minimal LML invocation.
  */
-export function fuse(lensA: string, lensB: string): { descriptor: string; lml: LML } {
+export function fuse(
+  lensA: string,
+  lensB: string,
+): { descriptor: string; lml: LML } {
   return {
     descriptor: `${lensA} + ${lensB}`,
     lml: { invocation: `Combine ${lensA} with ${lensB}.` },
   };
 }
-

--- a/packages/core/src/fusion.ts
+++ b/packages/core/src/fusion.ts
@@ -1,0 +1,13 @@
+import type { LML } from './types';
+
+/**
+ * Deterministically combine two lens names.
+ * This stub simply concatenates them and builds a minimal LML invocation.
+ */
+export function fuse(lensA: string, lensB: string): { descriptor: string; lml: LML } {
+  return {
+    descriptor: `${lensA} + ${lensB}`,
+    lml: { invocation: `Combine ${lensA} with ${lensB}.` },
+  };
+}
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./lml";
 export * from "./veil";
+export * from "./fusion";

--- a/packages/core/test/fusion.test.ts
+++ b/packages/core/test/fusion.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { fuse } from '../src/fusion';
+import { describe, it, expect } from "vitest";
+import { fuse } from "../src/fusion";
 
-describe('fuse', () => {
-  it('fuses lenses deterministically', () => {
-expect(fuse('Rhetoric', 'Persona')).toMatchInlineSnapshot(`
+describe("fuse", () => {
+  it("fuses lenses deterministically", () => {
+    expect(fuse("Rhetoric", "Persona")).toMatchInlineSnapshot(`
 {
   "descriptor": "Rhetoric + Persona",
   "lml": {

--- a/packages/core/test/fusion.test.ts
+++ b/packages/core/test/fusion.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { fuse } from '../src/fusion';
+
+describe('fuse', () => {
+  it('fuses lenses deterministically', () => {
+expect(fuse('Rhetoric', 'Persona')).toMatchInlineSnapshot(`
+{
+  "descriptor": "Rhetoric + Persona",
+  "lml": {
+    "invocation": "Combine Rhetoric with Persona.",
+  },
+}
+`);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic lens fusion helper
- snapshot test for fuse
- use fusion in crucible UI with LML preview

## Testing
- `pnpm -r test`
- `pnpm -r lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4356c395c83278aff739008c3c58b